### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
-        maven { url "http://nexus:8081/nexus/content/groups/public" }
         maven { url "http://salesforce-marketingcloud.github.io/JB4A-SDK-Android/repository" }
+        maven { url "http://nexus:8081/nexus/content/groups/public" }
     }
 }
 


### PR DESCRIPTION
Our internal nexus maven repository was previously listed *before* the github.io maven repo, which causes android studio to hang when loading the project, as the dependencies cannot be met from the nexus repository without the vpn. 

Until this is accepted, the learning app as cloned is broken for users.